### PR TITLE
Fix OIDC scope typo in documentation

### DIFF
--- a/docs/8_advanced_options/1_configuration_file/1_oidc_login.md
+++ b/docs/8_advanced_options/1_configuration_file/1_oidc_login.md
@@ -39,7 +39,7 @@ more specific error details.
 ## Idp General Configuration Notes
 Your Idp should:
 - Support audience `your-certwarden-api.example.com:4055/certwarden/api`
-- Support scope `certwarden:superuser` and add this permission to users who should have access.
+- Support scope `certwarden:superadmin` and add this permission to users who should have access.
 :::warning
 Some Idps do not enforce RBAC by default (e.g., Auth0). You should ensure RBAC is enabled and
 test with unprivileged user(s) to ensure they do not have unintended Cert Warden access.


### PR DESCRIPTION
This PR fixes a typo in the OIDC login documentation where the required scope was incorrectly listed as `certwarden:superuser`.
The correct scope is `certwarden:superadmin`, which is consistent with the ADFS configuration example later in the document where it specifically mentions creating the `certwarden:superadmin` scope.

Changes made:
- Updated the scope from `certwarden:superuser` to `certwarden:superadmin` in the Idp General Configuration Notes section